### PR TITLE
Snap fix vault paths

### DIFF
--- a/Dockerfile.vault
+++ b/Dockerfile.vault
@@ -26,17 +26,14 @@ COPY local-tls.json ./local.json
 WORKDIR /vault
 COPY pki-setup.sh .
 COPY pki-setup-config-vault.env .
+COPY vault-setup.sh .
 
 # install pre-requisites for pki setup: bash/openssl, pki/tls setup and housekeeping
 RUN apk --no-cache update && \
     apk --no-cache add bash openssl && \
-    chown -R vault:vault /vault && \
-    chmod 644 /vault/config/local.json && \
     chmod 744 pki-setup* && \
-    ./pki-setup.sh pki-setup-config-vault.env && \
-    chown -R vault:vault /vault/pki && \
-    chmod 750 /vault/pki && \
-    chmod 640 /vault/pki/*/* && \ 
+    chmod 744 vault-setup* && \
+    ./vault-setup.sh && \
     apk del --purge bash openssl && \
     rm -f /vault/pki-setup.sh /vault/pki-setup-config-vault.env && \
     rm -f /var/cache/apk/*

--- a/vault-init-unseal.sh
+++ b/vault-init-unseal.sh
@@ -190,7 +190,7 @@ function vaultRegistered() {
 #===================================== MAIN INIT ===============================
 
 # Variables and parameters
-_VAULT_DIR="/vault"
+_VAULT_DIR=${_VAULT_DIR:-/vault}
 _VAULT_CONFIG_DIR="${_VAULT_DIR}/config"
 _VAULT_PKI_DIR="${_VAULT_DIR}/pki"
 _VAULT_FILE_DIR="${_VAULT_DIR}/file"

--- a/vault-kong.sh
+++ b/vault-kong.sh
@@ -35,7 +35,7 @@ function houseKeeping() {
 #===================================== MAIN ====================================
 
 # Variables and parameters
-_VAULT_DIR="/vault"
+_VAULT_DIR=${_VAULT_DIR:-/vault}
 _VAULT_CONFIG_DIR="${_VAULT_DIR}/config"
 _VAULT_PKI_DIR="${_VAULT_DIR}/pki"
 _VAULT_FILE_DIR="${_VAULT_DIR}/file"
@@ -69,7 +69,7 @@ houseKeeping # temp files and payloads
 # Generate Kong PKI/TLS materials if they haven't been already...
 if [[ (! -f ${_KONG_PEM}) || (! -f ${_KONG_SK}) ]]; then
     echo ">> (3) Create PKI materials for Kong TLS server certificate"
-    /vault/pki-setup.sh /vault/pki-setup-config-kong.env
+    ${_VAULT_DIR}/pki-setup.sh ${_VAULT_DIR}/pki-setup-config-kong.env
     chown vault:vault ${_CA_DIR}/${_KONG_SVC}.*
 else
     echo ">> (3) PKI materials for Kong TLS server certificate already created"

--- a/vault-kong.sh
+++ b/vault-kong.sh
@@ -63,13 +63,14 @@ _VAULT_SVC="edgex-vault"
 _EDGEX_DOMAIN=""
 _VAULT_PORT="8200"
 _VAULT_API_PATH_KONG="/v1/secret/edgex/pki/tls/${_KONG_SVC}"
+_PKI_SETUP_KONG_ENV=${_PKI_SETUP_KONG_ENV:-pki-setup-config-kong.env}
 
 houseKeeping # temp files and payloads
 
 # Generate Kong PKI/TLS materials if they haven't been already...
 if [[ (! -f ${_KONG_PEM}) || (! -f ${_KONG_SK}) ]]; then
     echo ">> (3) Create PKI materials for Kong TLS server certificate"
-    ${_VAULT_DIR}/pki-setup.sh ${_VAULT_DIR}/pki-setup-config-kong.env
+    ${_VAULT_DIR}/pki-setup.sh ${_PKI_SETUP_KONG_ENV}
     chown vault:vault ${_CA_DIR}/${_KONG_SVC}.*
 else
     echo ">> (3) PKI materials for Kong TLS server certificate already created"

--- a/vault-setup.sh
+++ b/vault-setup.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#  ----------------------------------------------------------------------------------
+#  vault-setup.sh    version 1.0 created July 18, 2018
+#
+#  @author:  Tony Espy, Canonical
+#  @email:   espy@canonical.com
+#
+#  Copyright (c) 2018, Canonical Ltd
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#  ----------------------------------------------------------------------------------
+
+# Variables and parameters
+echo ">> Setup _VAULT_DIR and fix permissions"
+_VAULT_DIR=${_VAULT_DIR:-/vault}
+_PKI_SETUP_VAULT_ENV=${_PKI_SETUP_VAULT_ENV:-pki-setup-config-vault.env}
+
+./pki-setup.sh ${_PKI_SETUP_VAULT_ENV}
+
+# Don't chown in snap, as snaps don't support daemons using
+# setuid/gid to drop from root to a specified user/group.
+if [ -z "$SNAP" ]; then
+    chown -R vault:vault ${_VAULT_DIR}
+    chown -R vault:vault ${_VAULT_DIR}/pki
+fi
+
+chmod 644 ${_VAULT_DIR}/config/local.json
+chmod 750 ${_VAULT_DIR}/pki
+chmod 640 ${_VAULT_DIR}/pki/*/*

--- a/vault-worker.sh
+++ b/vault-worker.sh
@@ -23,14 +23,17 @@
 #  limitations under the License.
 #  ----------------------------------------------------------------------------------
 
+# Variables and parameters
+_VAULT_DIR=${_VAULT_DIR:-/vault}
+
 while true
 do
    # Init/Unseal processes
-   /vault/vault-init-unseal.sh
+   ${_VAULT_DIR}/vault-init-unseal.sh
 
    # If Vault init/unseal was OK... eventually prepare materials for Kong
    if [[ $? == 0 ]]; then
-       /vault/vault-kong.sh
+       ${_VAULT_DIR}/vault-kong.sh
    fi
 
    sleep ${WATCHDOG_DELAY}


### PR DESCRIPTION
The first change in this PR updates the initial scripts to check for a pre-existing value for **_VAULT_DIR** and if none found, set it to the default value "/vault".

The second change makes a similar change in **pki-setup.sh**, and extracts some of the logic from DockerFile.vault such that it can be shared with the snap package.

Although I've tested that the shell script work as expected, I don't have the capacity to test the DockerFile change without some assistance.