### PR TITLE
Kong PKI setup relocated to Vault service and volume removal

### DIFF
--- a/Dockerfile.vault
+++ b/Dockerfile.vault
@@ -26,14 +26,19 @@ COPY local-tls.json ./local.json
 WORKDIR /vault
 COPY pkisetup.src/pkisetup .
 COPY pkisetup.src/pkisetup-vault.json .
+# Kong PKI/TLS setup/config and X.509 materials
+COPY pkisetup.src/pkisetup-kong.json .
 
-# Run Vault PKI/TLS setup and housekeeping
-RUN chown -R vault:vault /vault && \
+# Create assets folder (needed for unseal key/s, root token and tmp)
+# Run CA/Vault and Kong PKI/TLS setups and peform housekeeping tasks
+RUN mkdir /vault/config/assets && \
+    chown -R vault:vault /vault && \
     chmod 644 /vault/config/local.json && \
     chmod 744 pkisetup* && \
     ./pkisetup --config pkisetup-vault.json && \
-    chown -R vault:vault /vault/pki && \
-    rm -f /vault/pkisetup /vault/pkisetup-vault.json
+    echo "" && \
+    ./pkisetup --config pkisetup-kong.json && \
+    chown -R vault:vault /vault/config/pki && \
+    rm -f /vault/pkisetup /vault/pkisetup-vault.json /vault/pkisetup-kong.json
 
 VOLUME /vault/config
-VOLUME /vault/pki

--- a/Dockerfile.vault-worker
+++ b/Dockerfile.vault-worker
@@ -24,12 +24,9 @@ WORKDIR /vault
 
 # Copy main launcher [CMD]
 COPY vault-worker.sh .
-# Copy init-unseal process
+# Copy Vault init/unseal process
 COPY vault-init-unseal.sh .
-# Copy PKI/TLS binary/config for Kong
-COPY pkisetup.src/pkisetup .
-COPY pkisetup.src/pkisetup-kong.json .
-# Copy PKI/TLS setup and Vault import for Kong
+# Copy PKI/TLS Vault import for Kong
 COPY vault-kong.sh .
 
 # Create a vault user and group so the IDs get set the same way
@@ -37,8 +34,8 @@ COPY vault-kong.sh .
 # Install pre-requisites for pki setup: bash/curl/jq/dig/openssl
 RUN addgroup vault && \
     adduser -S -G vault vault && \
-    chmod 700 vault-*.sh pkisetup* && \
-    chown vault:vault vault-*.sh pkisetup* && \
+    chmod 700 vault-*.sh && \
+    chown vault:vault vault-*.sh && \
     apk --no-cache update && \
     apk --no-cache add bash curl jq bind-tools openssl && \
     rm -f /var/cache/apk/*

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ docker_vault: build
 		-t edgexfoundry/docker-edgex-vault:latest \
 		.
 
-docker_vault_worker: build
+docker_vault_worker: 
 	docker build \
         --no-cache=true --rm=true \
 		-f Dockerfile.vault-worker \

--- a/docker-compose-california-0.6.0.yml
+++ b/docker-compose-california-0.6.0.yml
@@ -23,7 +23,6 @@ volumes:
   consul-config:
   consul-data:
   vault-config:
-  vault-pki:
   vault-file:
   vault-logs:
 
@@ -93,7 +92,6 @@ services:
       - 'VAULT_UI=true'
     volumes:
       - vault-config:/vault/config
-      - vault-pki:/vault/pki
       - vault-file:/vault/file
       - vault-logs:/vault/logs
     depends_on:
@@ -109,8 +107,7 @@ services:
     environment:
       - 'WATCHDOG_DELAY=3m'
     volumes:
-      - vault-pki:/vault/pki
-      - vault-file:/vault/file
+      - vault-config:/vault/config
     depends_on:
       - volume
       - consul

--- a/local-tls.json
+++ b/local-tls.json
@@ -3,9 +3,9 @@ listener "tcp" {
   tls_disable = "0" 
   cluster_address = "edgex-vault:8201"
   tls_min_version = "tls12"
-  tls_client_ca_file ="/vault/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem"
-  tls_cert_file ="/vault/pki/EdgeXFoundryCA/edgex-vault.pem"
-  tls_key_file = "/vault/pki/EdgeXFoundryCA/edgex-vault.priv.key"
+  tls_client_ca_file ="/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem"
+  tls_cert_file ="/vault/config/pki/EdgeXFoundryCA/edgex-vault.pem"
+  tls_key_file = "/vault/config/pki/EdgeXFoundryCA/edgex-vault.priv.key"
 }
 
 backend "consul" {

--- a/pkisetup.src/pkisetup-kong.json
+++ b/pkisetup.src/pkisetup-kong.json
@@ -1,6 +1,6 @@
 {
     "create_new_rootca": "false",
-    "working_dir": ".",
+    "working_dir": "./config",
     "pki_setup_dir": "pki",
     "dump_config": "true",
     "key_scheme": {

--- a/pkisetup.src/pkisetup-vault.json
+++ b/pkisetup.src/pkisetup-vault.json
@@ -1,6 +1,6 @@
 {
     "create_new_rootca": "true",
-    "working_dir": ".",
+    "working_dir": "./config",
     "pki_setup_dir": "pki",
     "dump_config": "true",
     "key_scheme": {

--- a/vault-init-unseal.sh
+++ b/vault-init-unseal.sh
@@ -192,15 +192,15 @@ function vaultRegistered() {
 # Variables and parameters
 _VAULT_DIR="/vault"
 _VAULT_CONFIG_DIR="${_VAULT_DIR}/config"
-_VAULT_PKI_DIR="${_VAULT_DIR}/pki"
-_VAULT_FILE_DIR="${_VAULT_DIR}/file"
+_VAULT_PKI_DIR="${_VAULT_CONFIG_DIR}/pki"
+_VAULT_ASSETS="${_VAULT_CONFIG_DIR}/assets"
 
-_PAYLOAD_INIT="${_VAULT_FILE_DIR}/payload-init.json"
-_PAYLOAD_UNSEAL="${_VAULT_FILE_DIR}/payload-unseal.json"
-_RESP_INIT="${_VAULT_FILE_DIR}/resp-init.json"
-_RESP_UNSEAL="${_VAULT_FILE_DIR}/resp-unseal.json"
+_PAYLOAD_INIT="${_VAULT_ASSETS}/payload-init.json"
+_PAYLOAD_UNSEAL="${_VAULT_ASSETS}/payload-unseal.json"
+_RESP_INIT="${_VAULT_ASSETS}/resp-init.json"
+_RESP_UNSEAL="${_VAULT_ASSETS}/resp-unseal.json"
 _VAULT_CONFIG="${_VAULT_CONFIG_DIR}/local.json"
-_TMP="${_VAULT_FILE_DIR}/_tmp.vault"
+_TMP="${_VAULT_ASSETS}/_tmp.vault"
 _EXIT="0"
 
 _CA="EdgeXFoundryCA"


### PR DESCRIPTION
pkisetup is now removed from Vault worker service, both Vault and Kong PKI/TLS materials are created in the Vault service (image) using pkisetup Golang tool.
The /vault/file volume usage has been removed for the PKI setup, /vault/config/pki is the new location. The compose file was impacted, and the makefile as the build stage is not needed for the Vault worker image.
