### PR TITLE
Fix NewClient arguments

### DIFF
--- a/core/main.go
+++ b/core/main.go
@@ -18,7 +18,7 @@ var lc = CreateLogging()
 
 // CreateLogging Logger functionality
 func CreateLogging() logger.LoggingClient {
-	return logger.NewClient(SecurityService, false, fmt.Sprintf("%s-%s.log", SecurityService, time.Now().Format("2006-01-02")))
+	return logger.NewClient(SecurityService, false, fmt.Sprintf("%s-%s.log", SecurityService, time.Now().Format("2006-01-02")), logger.InfoLog)
 }
 
 func main() {

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,5 +9,6 @@ import:
 - package: github.com/hashicorp/vault/api
   version: v0.11.3  
 - package: github.com/edgexfoundry/edgex-go
+  version: delhi
   subpackages:
   - pkg/clients/logging


### PR DESCRIPTION
Fixes #35 

Also specifies the version of edgex-go to build with as delhi, which is needed for reproducible builds and to ensure bugfixes to delhi in master propagate here.