### PR TITLE
vault-policy-kong.hcl: adjust kong certs path access

### DIFF
--- a/core/res/vault-policy-kong.hcl
+++ b/core/res/vault-policy-kong.hcl
@@ -4,7 +4,7 @@ path "secret/edgex/edgex-kong/*" {
 }
 
 # List/Read only for the TLS materials: private key and certificate
-path "secret/edgex/pki/tls/edgex-kong/*" {
+path "secret/edgex/pki/tls/edgex-kong" {
   capabilities = ["list", "read"]
 }
 


### PR DESCRIPTION
This allows the edgexproxy binary from security-api-gateway to pull the certs that are stored in vault down and then upload those certs for kong to use.

Fixes #38 for Delhi